### PR TITLE
Expected Returns incorrectly based on first simulated path

### DIFF
--- a/Final.R
+++ b/Final.R
@@ -898,8 +898,8 @@ for(y in 1:4)
             maxReturnsSim[,j] <- returnsSim
             
             
-            monthlyReturns[,j] = GetMonthlyReturns(100,stratLength[y],maxReturnsSim,stratMatrix[,j])
-            meanExpectedReturns[j] = GetExpectedReturns(100,stratLength[y],maxReturnsSim,pSuccess[p])
+            monthlyReturns[,j] = GetMonthlyReturns(100,stratLength[y],maxReturnsSim[,j],stratMatrix[,j])
+            meanExpectedReturns[j] = GetExpectedReturns(100,stratLength[y],maxReturnsSim[,j],pSuccess[p])
             
             dmBias[j] = GetDMB(stratNos[k],maxStratReturns[j],meanExpectedReturns[j])
           


### PR DESCRIPTION
Got the link to this repo from Emlyn, as an example of implementation of WRC and MCP test.

Must say, really an incredible paper!

When going through the code I realised it generates 100 simulated paths (Symbol N in the paper). 

This is done with the j-loop from 1 to 100.

But it keeps referencing the first simulated path when calculating the expected returns.

Pretty sure this is mistake, and it should use the j-th path.